### PR TITLE
snipcart_currency as an option in yaml

### DIFF
--- a/snipcart.yaml
+++ b/snipcart.yaml
@@ -1,3 +1,5 @@
 enabled: true
 built_in_css: true
 api_key: YOUR_API_KEY
+currency_symbol: $
+

--- a/templates/partials/snipcart_detail_item.html.twig
+++ b/templates/partials/snipcart_detail_item.html.twig
@@ -8,7 +8,7 @@
                 {{ snipcart_image.cropResize(400,400).html(page.header.title,'snipcart-thumb-image')|raw }}
             {% endif %}
             <span class="snipcart-price">
-            ${{ page.header.price }}
+                <span class="snipcart-currency">{{ header.snipcart.currency_symbol ?? '$' }}</span>{{ page.header.price }}
             </span>
         </div>
         <p>

--- a/templates/partials/snipcart_product_item.html.twig
+++ b/templates/partials/snipcart_product_item.html.twig
@@ -8,7 +8,7 @@
             <a href="{{ page.url }}">{{ snipcart_image.cropResize(200,200).html('page.header.title','snipcart-thumb-image')|raw }}</a>
         {% endif %}
         <span class="snipcart-price">
-        ${{ page.header.price }}
+            <span class="snipcart-currency">{{ header.snipcart.currency_symbol ?? '$' }}</span>{{ page.header.price }}
         </span>
     </div>
     <div class="snipcart-details">

--- a/templates/partials/snipcart_subscription_item.html.twig
+++ b/templates/partials/snipcart_subscription_item.html.twig
@@ -8,7 +8,7 @@
                 {{ snipcart_image.cropResize(400,400).html(page.header.title,'snipcart-thumb-image')|raw }}
             {% endif %}
             <span class="snipcart-price">
-            ${{ page.header.price }}
+                <span class="snipcart-currency">{{ header.snipcart.currency_symbol ?? '$' }}</span>{{ page.header.price }}
             </span>
         </div>
         <p>

--- a/templates/partials/snipcart_subscription_item_small.html.twig
+++ b/templates/partials/snipcart_subscription_item_small.html.twig
@@ -8,7 +8,7 @@
             <a href="{{ page.url }}">{{ snipcart_image.cropResize(200,200).html('page.header.title','snipcart-thumb-image')|raw }}</a>
         {% endif %}
         <span class="snipcart-price">
-            ${{ page.header.price }}<span class="snipcart-interval">/{{ page.header.interval }}</span>
+            <span class="snipcart-currency">{{ header.snipcart.currency_symbol ?? '$' }}</span>{{ page.header.price }}<span class="snipcart-interval">/{{ page.header.interval }}</span>
         </span>
     </div>
     <div class="snipcart-details">


### PR DESCRIPTION
As a user within Europe the Current EUR needs the symbol **'€'** for the price - the templates had just **'$'** hardcoded.

This push allows for setting 'currency_symbol' in the `snipcart.yaml` - fallback if undefined is still '$'