### PR TITLE
V2 Update: Translations, Admin Options, more Snipcart Features

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -17,28 +17,28 @@ form:
   fields:
     enabled:
       type: toggle
-      label: Plugin status
+      label: PLUGIN_ADMIN.PLUGIN_STATUS
       highlight: 1
       default: 0
       options:
-        1: Enabled
-        0: Disabled
+        1: PLUGIN_ADMIN.ENABLED
+        0: PLUGIN_ADMIN.DISABLED
       validate:
         type: bool
 
     built_in_css:
       type: toggle
-      label: Use built in CSS
+      label: PLUGIN_SNIPCART.SETTINGS.BUILT_IN_CSS
       highlight: 1
       default: 1
       options:
-        1: Enabled
-        0: Disabled
+        1: PLUGIN_ADMIN.ENABLED
+        0: PLUGIN_ADMIN.DISABLED
       validate:
         type: bool
 
     api_key:
       type: text
       size: medium
-      label: API Key
+      label: PLUGIN_SNIPCART.SETTINGS.API_KEY
       default: 'YOUR_API_KEY'

--- a/blueprints/partials/modular-parts.yaml
+++ b/blueprints/partials/modular-parts.yaml
@@ -17,10 +17,10 @@ form:
       default: date
       size: small
       options:
-        folder: TEMPLATE.PARTIALS.COLLECTION.ORDER_BY.OPTIONS.FOLDER
-        title: TEMPLATE.PARTIALS.COLLECTION.ORDER_BY.OPTIONS.TITLE
-        date: TEMPLATE.PARTIALS.COLLECTION.ORDER_BY.OPTIONS.DATE
-        default: TEMPLATE.PARTIALS.COLLECTION.ORDER_BY.OPTIONS.DEFAULT
+        folder: PLUGIN_ADMIN.FOLDER
+        title: PLUGIN_ADMIN.PAGE_TITLE
+        date: PLUGIN_ADMIN.DATE
+        default: PLUGIN_ADMIN.DEFAULT
 
     header.content.order.dir:
       type: select
@@ -28,5 +28,5 @@ form:
       default: desc
       size: small
       options:
-        asc: TEMPLATE.PARTIALS.COLLECTION.ORDER_DIR.OPTIONS.ASC
-        desc: TEMPLATE.PARTIALS.COLLECTION.ORDER_DIR.OPTIONS.DESC
+        asc: PLUGIN_ADMIN.ASCENDING
+        desc: PLUGIN_ADMIN.DESCENDING

--- a/blueprints/partials/modular-parts.yaml
+++ b/blueprints/partials/modular-parts.yaml
@@ -1,0 +1,32 @@
+form:
+  fields:
+
+    modular_title:
+      type: spacer
+      title: PLUGIN_ADMIN.MODULE_SETUP
+
+    header.content.items:
+      type: text
+      label: PLUGIN_ADMIN.ITEMS
+      default: '@self.modular'
+      size: medium
+
+    header.content.order.by:
+      type: select
+      label: PLUGIN_ADMIN.ORDER_BY
+      default: date
+      size: small
+      options:
+        folder: TEMPLATE.PARTIALS.COLLECTION.ORDER_BY.OPTIONS.FOLDER
+        title: TEMPLATE.PARTIALS.COLLECTION.ORDER_BY.OPTIONS.TITLE
+        date: TEMPLATE.PARTIALS.COLLECTION.ORDER_BY.OPTIONS.DATE
+        default: TEMPLATE.PARTIALS.COLLECTION.ORDER_BY.OPTIONS.DEFAULT
+
+    header.content.order.dir:
+      type: select
+      label: PLUGIN_ADMIN.ORDER
+      default: desc
+      size: small
+      options:
+        asc: TEMPLATE.PARTIALS.COLLECTION.ORDER_DIR.OPTIONS.ASC
+        desc: TEMPLATE.PARTIALS.COLLECTION.ORDER_DIR.OPTIONS.DESC

--- a/blueprints/snipcart.yaml
+++ b/blueprints/snipcart.yaml
@@ -1,0 +1,17 @@
+title: Snipcart
+extends@: default
+
+form:
+  fields:
+    tabs:
+      fields:
+        content:
+
+          import@:
+            ordering@: 5
+            type: partials/modular-parts
+            context: blueprints://pages
+
+          fields:
+            modular_title:
+              title: Snipcart Items

--- a/blueprints/snipcart.yaml
+++ b/blueprints/snipcart.yaml
@@ -14,4 +14,4 @@ form:
 
           fields:
             modular_title:
-              title: Snipcart Items
+              title: PLUGIN_SNIPCART.PAGE_OPTIONS.DEFAULT.MODULAR_TITLE

--- a/blueprints/snipcart_category.yaml
+++ b/blueprints/snipcart_category.yaml
@@ -14,4 +14,4 @@ form:
 
           fields:
             modular_title:
-              title: Snipcart Items
+              title: PLUGIN_SNIPCART.PAGE_OPTIONS.CATEGORY.MODULAR_TITLE

--- a/blueprints/snipcart_category.yaml
+++ b/blueprints/snipcart_category.yaml
@@ -1,0 +1,17 @@
+title: Snipcart Category
+extends@: default
+
+form:
+  fields:
+    tabs:
+      fields:
+        content:
+
+          import@:
+            ordering@: 5
+            type: partials/modular-parts
+            context: blueprints://pages
+
+          fields:
+            modular_title:
+              title: Snipcart Items

--- a/blueprints/snipcart_detail.yaml
+++ b/blueprints/snipcart_detail.yaml
@@ -19,26 +19,26 @@ form:
               type: spacer
               title: Snipcart
 
-            header.product_id:
+            header.snipcart.product_id:
               type: text
               label: Product ID
               size: small
               validate:
                 required: true
 
-            header.price:
+            header.snipcart.price:
               type: number
               label: Price
               size: small
               validate:
                 required: true
 
-            header.weight:
+            header.snipcart.weight:
               type: number
               label: Weight
               size: small
 
-            header.description:
+            header.snipcart.description:
               type: text
               label: Description
               size: long

--- a/blueprints/snipcart_detail.yaml
+++ b/blueprints/snipcart_detail.yaml
@@ -1,4 +1,4 @@
-title: Snipcart Detail
+title: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.TITLE
 extends@:
   type: default
   context: blueprints://pages
@@ -14,13 +14,13 @@ form:
             header.snipcart.description:
               ordering@: 2
               type: text
-              label: Description
+              label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.DESCRIPTION.LABEL
               style: vertical
               size: long
 
         snipcart:
           type: tab
-          title: Snipcart Item
+          title: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.TITLE
           fields:
 
             snipcart_title:
@@ -29,21 +29,21 @@ form:
 
             header.snipcart.product_id:
               type: text
-              label: Product ID
+              label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.PRODUCT_ID.LABEL
               size: small
               validate:
                 required: true
 
             header.snipcart.price:
               type: number
-              label: Price
+              label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.PRICE.LABEL
               size: small
               validate:
                 required: true
 
             header.snipcart.categories:
               type: selectize
-              label: Categories
+              label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.CATEGORIES.LABEL
               toggleable: true
               size: medium
               validate:
@@ -51,13 +51,13 @@ form:
 
             header.snipcart.file_guid:
               type: text
-              label: File GUID
+              label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.FILE_GUID.LABEL
               toggleable: true
               size: medium
 
             header.snipcart.stackable:
               type: toggle
-              label: Stackable
+              label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.STACKABLE.LABEL
               size: small
               toggleable: true
               highlight: 1
@@ -70,7 +70,7 @@ form:
 
             header.snipcart.shipable:
               type: toggle
-              label: Shipable
+              label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.SHIPABLE.LABEL
               size: small
               toggleable: true
               highlight: 1
@@ -83,7 +83,7 @@ form:
 
             header.snipcart.taxable:
               type: toggle
-              label: Taxable
+              label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.TAXABLE.LABEL
               size: small
               toggleable: true
               highlight: 1
@@ -96,75 +96,75 @@ form:
 
             header.snipcart.metadata:
               type: textarea
-              label: JSON Metadata
+              label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.METADATA.LABEL
               toggleable: true
 
             dimensions:
               type: section
-              title: Shipping Dimensions
+              title: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.DIMENSIONS.TITLE
               fields:
 
                 header.snipcart.dimensions.weight:
                   type: number
-                  label: Weight (g)
+                  label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.DIMENSIONS.WEIGHT.LABEL
                   toggleable: true
                   size: small
 
                 header.snipcart.dimensions.width:
                   type: number
-                  label: Width (cm)
+                  label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.DIMENSIONS.WIDTH.LABEL
                   toggleable: true
                   size: small
 
                 header.snipcart.dimensions.length:
                   type: number
-                  label: Length (cm)
+                  label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.DIMENSIONS.LENGTH.LABEL
                   toggleable: true
                   size: small
 
                 header.snipcart.dimensions.height:
                   type: number
-                  label: Height (cm)
+                  label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.DIMENSIONS.HEIGHT.LABEL
                   toggleable: true
                   size: small
 
             quantity:
               type: section
-              title: Quantity
+              title: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.QUANTITY.TITLE
               fields:
 
                 header.snipcart.quantity.quantity:
                   type: number
-                  label: Default Quantity
+                  label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.QUANTITY.QUANTITY.LABEL
                   toggleable: true
                   size: small
 
                 header.snipcart.quantity.min_quantity:
                   type: number
-                  label: Min Quantity
+                  label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.QUANTITY.MIN.LABEL
                   toggleable: true
                   size: small
 
                 header.snipcart.quantity.max_quantity:
                   type: number
-                  label: Max Quantity
+                  label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.QUANTITY.MAX.LABEL
                   toggleable: true
                   size: small
 
                 header.snipcart.quantity.quantity_step:
                   type: number
-                  label: Quantity Step
+                  label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.QUANTITY.STEPS.LABEL
                   toggleable: true
                   size: small
 
             taxes:
               type: section
-              title: Taxes
+              title: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.TAXES.TITLE
               fields:
 
                 header.snipcart.taxes.taxes:
                   type: selectize
-                  label: Taxes to apply
+                  label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.TAXES.TAXES.LABEL
                   toggleable: true
                   size: medium
                   validate:
@@ -172,7 +172,7 @@ form:
 
                 header.snipcart.taxes.has_included:
                   type: toggle
-                  label: Taxes included
+                  label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.TAXES.INCLUDED.LABEL
                   size: small
                   toggleable: true
                   highlight: 0
@@ -185,40 +185,40 @@ form:
 
             payment:
               type: section
-              title: Payment
+              title: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.PAYMENT.TITLE
               fields:
 
                 header.snipcart.payment.interval:
                   type: select
-                  label: Interval
+                  label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.PAYMENT.INTERVAL.LABEL
                   toggleable: true
                   size: medium
                   options:
-                    Day: Day
-                    Week: Week
-                    Month: Month
-                    Year: Year
+                    Day: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.PAYMENT.INTERVAL.OPTIONS.DAY.LABEL
+                    Week: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.PAYMENT.INTERVAL.OPTIONS.WEEK.LABEL
+                    Month: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.PAYMENT.INTERVAL.OPTIONS.MONTH.LABEL
+                    Year: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.PAYMENT.INTERVAL.OPTIONS.YEAR.LABEL
 
                 header.snipcart.payment.interval_count:
                   type: number
-                  label: Interval Count
+                  label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.PAYMENT.COUNT.LABEL
                   toggleable: true
                   size: small
 
                 header.snipcart.payment.trial:
                   type: number
-                  label: Trial Days
+                  label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.PAYMENT.TRIAL.LABEL
                   toggleable: true
                   size: small
 
             subscription:
               type: section
-              title: Subscription
+              title: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.SUBSCRIPTION.TITLE
               fields:
 
                 header.snipcart.subscription.recurring_shipping:
                   type: toggle
-                  label: Recurring Shipping
+                  label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.SUBSCRIPTION.RECURRING_SHIPPING.LABEL
                   size: small
                   toggleable: true
                   highlight: 1
@@ -231,18 +231,18 @@ form:
 
                 header.snipcart.subscription.cancellation_action:
                   type: select
-                  label: Cancellation Action
+                  label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.SUBSCRIPTION.CANCELLATION_ACTION.LABEL
                   toggleable: true
                   size: medium
                   options:
-                    PartialRefundLastPayment: Partial Refund Last Payment
-                    CancelAtCurrentCycleEnd: Cancel At Current Cycle End
+                    PartialRefundLastPayment: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.SUBSCRIPTION.CANCELLATION_ACTION.OPTIONS.PARTIAL
+                    CancelAtCurrentCycleEnd: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.SUBSCRIPTION.CANCELLATION_ACTION.OPTIONS.CANCEL
 
                 header.snipcart.subscription.pausing_action:
                   type: select
-                  label: Pausing Action
+                  label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.SUBSCRIPTION.PAUSING_ACTION.LABEL
                   toggleable: true
                   size: medium
                   options:
-                    KeepActiveUntilEndOfBillingCycle: Keep Active Until End Of Billing Cycle
-                    PauseAndRealignBillingCycleOnResume: Pause And Realign Billing Cycle On Resume
+                    KeepActiveUntilEndOfBillingCycle: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.SUBSCRIPTION.PAUSING_ACTION.OPTIONS.KEEP
+                    PauseAndRealignBillingCycleOnResume: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.SUBSCRIPTION.PAUSING_ACTION.OPTIONS.PAUSE

--- a/blueprints/snipcart_detail.yaml
+++ b/blueprints/snipcart_detail.yaml
@@ -12,7 +12,7 @@ form:
 
         snipcart:
           type: tab
-          title: Snipcart
+          title: Snipcart Item
           fields:
 
             snipcart_title:
@@ -23,11 +23,15 @@ form:
               type: text
               label: Product ID
               size: small
+              validate:
+                required: true
 
             header.price:
               type: number
               label: Price
               size: small
+              validate:
+                required: true
 
             header.weight:
               type: number

--- a/blueprints/snipcart_detail.yaml
+++ b/blueprints/snipcart_detail.yaml
@@ -1,0 +1,41 @@
+title: Snipcart Detail
+extends@:
+  type: default
+  context: blueprints://pages
+
+form:
+  fields:
+    tabs:
+      type: tabs
+      active: 1
+      fields:
+
+        snipcart:
+          type: tab
+          title: Snipcart
+          fields:
+
+            snipcart_title:
+              type: spacer
+              title: Snipcart
+
+            header.product_id:
+              type: text
+              label: Product ID
+              size: small
+
+            header.price:
+              type: number
+              label: Price
+              size: small
+
+            header.weight:
+              type: number
+              label: Weight
+              size: small
+
+            header.description:
+              type: text
+              label: Description
+              size: long
+

--- a/blueprints/snipcart_detail.yaml
+++ b/blueprints/snipcart_detail.yaml
@@ -9,6 +9,14 @@ form:
       type: tabs
       active: 1
       fields:
+        content:
+          fields:
+            header.snipcart.description:
+              ordering@: 2
+              type: text
+              label: Description
+              style: vertical
+              size: long
 
         snipcart:
           type: tab
@@ -40,12 +48,6 @@ form:
               size: medium
               validate:
                 type: commalist
-
-            header.snipcart.description: # TODO: move to content below title?
-              type: text
-              label: Description
-              toggleable: true
-              size: long
 
             header.snipcart.file_guid:
               type: text
@@ -92,7 +94,7 @@ form:
               validate:
                 type: bool
 
-            header.snipcart.metadata: # TODO: to JSON
+            header.snipcart.metadata:
               type: textarea
               label: JSON Metadata
               toggleable: true

--- a/blueprints/snipcart_detail.yaml
+++ b/blueprints/snipcart_detail.yaml
@@ -246,3 +246,44 @@ form:
                   options:
                     KeepActiveUntilEndOfBillingCycle: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.SUBSCRIPTION.PAUSING_ACTION.OPTIONS.KEEP
                     PauseAndRealignBillingCycleOnResume: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.SUBSCRIPTION.PAUSING_ACTION.OPTIONS.PAUSE
+
+            custom:
+              type: section
+              title: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.CUSTOM.TITLE
+              fields:
+
+                header.snipcart.custom:
+                  type: list
+                  label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.CUSTOM.TITLE
+                  toggleable: true
+                  style: horizontal
+                  fields:
+
+                    .name:
+                      type: text
+                      label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.CUSTOM.NAME.LABEL
+                      size: medium
+                      validate:
+                        required: true
+
+                    .options:
+                      type: selectize
+                      label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.CUSTOM.OPTIONS.LABEL
+                      description: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.CUSTOM.OPTIONS.DESCRIPTION
+                      toggleable: true
+                      size: medium
+                      validate:
+                        type: commalist
+
+                    .required:
+                      type: toggle
+                      label: PLUGIN_SNIPCART.PAGE_OPTIONS.DETAIL.CUSTOM.REQUIRED.LABEL
+                      toggleable: true
+                      size: small
+                      highlight: 1
+                      default: 1
+                      options:
+                        1: PLUGIN_ADMIN.YES
+                        0: PLUGIN_ADMIN.NO
+                      validate:
+                        type: bool

--- a/blueprints/snipcart_detail.yaml
+++ b/blueprints/snipcart_detail.yaml
@@ -33,13 +33,112 @@ form:
               validate:
                 required: true
 
-            header.snipcart.weight:
-              type: number
-              label: Weight
-              size: small
+            header.snipcart.categories:
+              type: selectize
+              label: Categories
+              toggleable: true
+              size: medium
+              validate:
+                type: commalist
 
             header.snipcart.description:
               type: text
               label: Description
+              toggleable: true
               size: long
 
+            dimensions:
+              type: section
+              title: Shipping Dimensions
+              fields:
+
+                header.snipcart.dimensions.weight:
+                  type: number
+                  label: Weight (g)
+                  toggleable: true
+                  size: small
+
+                header.snipcart.dimensions.width:
+                  type: number
+                  label: Width (cm)
+                  toggleable: true
+                  size: small
+
+                header.snipcart.dimensions.length:
+                  type: number
+                  label: Length (cm)
+                  toggleable: true
+                  size: small
+
+                header.snipcart.dimensions.height:
+                  type: number
+                  label: Height (cm)
+                  toggleable: true
+                  size: small
+
+            quantity:
+              type: section
+              title: Quantity
+              fields:
+
+                header.snipcart.quantity.min_quantity:
+                  type: number
+                  label: Min Quantity
+                  toggleable: true
+                  size: small
+
+                header.snipcart.quantity.max_quantity:
+                  type: number
+                  label: Max Quantity
+                  toggleable: true
+                  size: small
+
+                header.snipcart.quantity.quantity_step:
+                  type: number
+                  label: Quantity Step
+                  toggleable: true
+                  size: small
+
+            options:
+              type: section
+              title: Options
+              fields:
+
+                header.snipcart.stackable:
+                  type: toggle
+                  label: Stackable
+                  size: small
+                  toggleable: true
+                  highlight: 1
+                  default: 1
+                  options:
+                    1: PLUGIN_ADMIN.ENABLED
+                    0: PLUGIN_ADMIN.DISABLED
+                  validate:
+                    type: bool
+
+                header.snipcart.shipable:
+                  type: toggle
+                  label: Shipable
+                  size: small
+                  toggleable: true
+                  highlight: 1
+                  default: 1
+                  options:
+                    1: PLUGIN_ADMIN.ENABLED
+                    0: PLUGIN_ADMIN.DISABLED
+                  validate:
+                    type: bool
+
+                header.snipcart.taxable:
+                  type: toggle
+                  label: Taxable
+                  size: small
+                  toggleable: true
+                  highlight: 1
+                  default: 1
+                  options:
+                    1: PLUGIN_ADMIN.ENABLED
+                    0: PLUGIN_ADMIN.DISABLED
+                  validate:
+                    type: bool

--- a/blueprints/snipcart_detail.yaml
+++ b/blueprints/snipcart_detail.yaml
@@ -41,11 +41,61 @@ form:
               validate:
                 type: commalist
 
-            header.snipcart.description:
+            header.snipcart.description: # TODO: move to content below title?
               type: text
               label: Description
               toggleable: true
               size: long
+
+            header.snipcart.file_guid:
+              type: text
+              label: File GUID
+              toggleable: true
+              size: medium
+
+            header.snipcart.stackable:
+              type: toggle
+              label: Stackable
+              size: small
+              toggleable: true
+              highlight: 1
+              default: 1
+              options:
+                1: PLUGIN_ADMIN.ENABLED
+                0: PLUGIN_ADMIN.DISABLED
+              validate:
+                type: bool
+
+            header.snipcart.shipable:
+              type: toggle
+              label: Shipable
+              size: small
+              toggleable: true
+              highlight: 1
+              default: 1
+              options:
+                1: PLUGIN_ADMIN.ENABLED
+                0: PLUGIN_ADMIN.DISABLED
+              validate:
+                type: bool
+
+            header.snipcart.taxable:
+              type: toggle
+              label: Taxable
+              size: small
+              toggleable: true
+              highlight: 1
+              default: 1
+              options:
+                1: PLUGIN_ADMIN.ENABLED
+                0: PLUGIN_ADMIN.DISABLED
+              validate:
+                type: bool
+
+            header.snipcart.metadata: # TODO: to JSON
+              type: textarea
+              label: JSON Metadata
+              toggleable: true
 
             dimensions:
               type: section
@@ -81,6 +131,12 @@ form:
               title: Quantity
               fields:
 
+                header.snipcart.quantity.quantity:
+                  type: number
+                  label: Default Quantity
+                  toggleable: true
+                  size: small
+
                 header.snipcart.quantity.min_quantity:
                   type: number
                   label: Min Quantity
@@ -99,14 +155,68 @@ form:
                   toggleable: true
                   size: small
 
-            options:
+            taxes:
               type: section
-              title: Options
+              title: Taxes
               fields:
 
-                header.snipcart.stackable:
+                header.snipcart.taxes.taxes:
+                  type: selectize
+                  label: Taxes to apply
+                  toggleable: true
+                  size: medium
+                  validate:
+                    type: commalist
+
+                header.snipcart.taxes.has_included:
                   type: toggle
-                  label: Stackable
+                  label: Taxes included
+                  size: small
+                  toggleable: true
+                  highlight: 0
+                  default: 0
+                  options:
+                    1: PLUGIN_ADMIN.YES
+                    0: PLUGIN_ADMIN.NO
+                  validate:
+                    type: bool
+
+            payment:
+              type: section
+              title: Payment
+              fields:
+
+                header.snipcart.payment.interval:
+                  type: select
+                  label: Interval
+                  toggleable: true
+                  size: medium
+                  options:
+                    Day: Day
+                    Week: Week
+                    Month: Month
+                    Year: Year
+
+                header.snipcart.payment.interval_count:
+                  type: number
+                  label: Interval Count
+                  toggleable: true
+                  size: small
+
+                header.snipcart.payment.trial:
+                  type: number
+                  label: Trial Days
+                  toggleable: true
+                  size: small
+
+            subscription:
+              type: section
+              title: Subscription
+              fields:
+
+                header.snipcart.subscription.recurring_shipping:
+                  type: toggle
+                  label: Recurring Shipping
                   size: small
                   toggleable: true
                   highlight: 1
@@ -117,28 +227,20 @@ form:
                   validate:
                     type: bool
 
-                header.snipcart.shipable:
-                  type: toggle
-                  label: Shipable
-                  size: small
+                header.snipcart.subscription.cancellation_action:
+                  type: select
+                  label: Cancellation Action
                   toggleable: true
-                  highlight: 1
-                  default: 1
+                  size: medium
                   options:
-                    1: PLUGIN_ADMIN.ENABLED
-                    0: PLUGIN_ADMIN.DISABLED
-                  validate:
-                    type: bool
+                    PartialRefundLastPayment: Partial Refund Last Payment
+                    CancelAtCurrentCycleEnd: Cancel At Current Cycle End
 
-                header.snipcart.taxable:
-                  type: toggle
-                  label: Taxable
-                  size: small
+                header.snipcart.subscription.pausing_action:
+                  type: select
+                  label: Pausing Action
                   toggleable: true
-                  highlight: 1
-                  default: 1
+                  size: medium
                   options:
-                    1: PLUGIN_ADMIN.ENABLED
-                    0: PLUGIN_ADMIN.DISABLED
-                  validate:
-                    type: bool
+                    KeepActiveUntilEndOfBillingCycle: Keep Active Until End Of Billing Cycle
+                    PauseAndRealignBillingCycleOnResume: Pause And Realign Billing Cycle On Resume

--- a/languages/de.yaml
+++ b/languages/de.yaml
@@ -1,5 +1,7 @@
 PLUGIN_SNIPCART:
   SETTINGS:
+    BUILT_IN_CSS: Verwende eingebautes CSS
+    API_KEY: API Schlüssel
   TEMPLATES:
     CHECKOUT: Kasse
     DETAILS: Details

--- a/languages/de.yaml
+++ b/languages/de.yaml
@@ -89,3 +89,12 @@ PLUGIN_SNIPCART:
           OPTIONS:
             KEEP: Beibehalten bis Ende des Abrechnungszeitraums
             PAUSE: Pausieren und Abrechnungszeitraums bei Wiederaufnahme anpassen
+      CUSTOM:
+        TITLE: Benutzerdefinierte Felder
+        NAME:
+          LABEL: Name
+        OPTIONS:
+          LABEL: Optionen
+          DESCRIPTION: 'Liste von Optionen: nutze `true,false` für Checkboxen, füge `[+10]` als Postfix hinzu, um einen Preisaufschlag hinzuzufügen'
+        REQUIRED:
+          LABEL: Erforderlich

--- a/languages/de.yaml
+++ b/languages/de.yaml
@@ -1,8 +1,10 @@
 PLUGIN_SNIPCART:
   SETTINGS:
   TEMPLATES:
-    CART:
-      CHECKOUT: Kasse
+    CHECKOUT: Kasse
+    DETAILS: Details
+    ADD: Hinzufügen
+    ADD_TO_CART: In den Warenkorb
   PAGE_OPTIONS:
     DEFAULT:
       MODULAR_TITLE: Snipcart Artikel

--- a/languages/de.yaml
+++ b/languages/de.yaml
@@ -1,0 +1,87 @@
+PLUGIN_SNIPCART:
+  SETTINGS:
+  TEMPLATES:
+    CART:
+      CHECKOUT: Kasse
+  PAGE_OPTIONS:
+    DEFAULT:
+      MODULAR_TITLE: Snipcart Artikel
+    CATEGORY:
+      MODULAR_TITLE: Snipcart Artikel
+    DETAIL:
+      TITLE: Snipcart Artikel
+      DESCRIPTION:
+        LABEL: Beschreibung
+      PRODUCT_ID:
+        LABEL: Produkt ID
+      PRICE:
+        LABEL: Preis
+      CATEGORIES:
+        LABEL: Kategorien
+      FILE_GUID:
+        LABEL: Datei GUID
+      STACKABLE:
+        LABEL: Stapelbar
+      SHIPABLE:
+        LABEL: Versandfähig
+      TAXABLE:
+        LABEL: Steuerpflichtig
+      METADATA:
+        LABEL: JSON Metadaten
+      DIMENSIONS:
+        TITLE: Versandabmessungen
+        WEIGHT:
+          LABEL: Gewicht (g)
+        WIDTH:
+          LABEL: Breite (cm)
+        LENGTH:
+          LABEL: Länge (cm)
+        HEIGHT:
+          LABEL: Höhe (cm)
+      QUANTITY:
+        TITLE: Menge
+        QUANTITY:
+          LABEL: Menge
+        MIN:
+          LABEL: Mindestmenge
+        MAX:
+          LABEL: Höchstmenge
+        STEPS:
+          LABEL: Mengenschritte
+      TAXES:
+        TITLE: Steuern
+        TAXES:
+          LABEL: Anzuwendende Steuern
+        INCLUDED:
+          LABEL: Enthaltene Steuern
+      PAYMENT:
+        TITLE: Zahlung
+        INTERVAL:
+          LABEL: Intervall
+          OPTIONS:
+            DAY:
+              LABEL: Tag
+            WEEK:
+              LABEL: Woche
+            MONTH:
+              LABEL: Monat
+            YEAR:
+              LABEL: Jahr
+        COUNT:
+          LABEL: Intervallanzahl
+        TRIAL:
+          LABEL: Probezeit (Tage)
+      SUBSCRIPTION:
+        TITLE: Abonnement
+        RECURRING_SHIPPING:
+          LABEL: Wiederkehrender Versand
+        CANCELLATION_ACTION:
+          LABEL: Kündigungsaktion
+          OPTIONS:
+            PARTIAL: Teilrückerstattung letzte Zahlung
+            CANCEL: Kündigen nach aktuellem Abrechnungszeitraum
+        PAUSING_ACTION:
+          LABEL: Pausierungsaktion
+          OPTIONS:
+            KEEP: Beibehalten bis Ende des Abrechnungszeitraums
+            PAUSE: Pausieren und Abrechnungszeitraums bei Wiederaufnahme anpassen

--- a/languages/en.yaml
+++ b/languages/en.yaml
@@ -1,8 +1,10 @@
 PLUGIN_SNIPCART:
   SETTINGS:
   TEMPLATES:
-    CART:
-      CHECKOUT: Checkout
+    CHECKOUT: Checkout
+    DETAILS: Details
+    ADD: Add
+    ADD_TO_CART: Add to Cart
   PAGE_OPTIONS:
     DEFAULT:
       MODULAR_TITLE: Snipcart Items

--- a/languages/en.yaml
+++ b/languages/en.yaml
@@ -89,3 +89,12 @@ PLUGIN_SNIPCART:
           OPTIONS:
             KEEP: Keep Active Until End Of Billing Cycle
             PAUSE: Pause And Realign Billing Cycle On Resume
+      CUSTOM:
+        TITLE: Custom Fields
+        NAME:
+          LABEL: Name
+        OPTIONS:
+          LABEL: Options
+          DESCRIPTION: 'List of options: use `true,false` for checkboxes, add `[+10]` as a postfix to add a price modifier'
+        REQUIRED:
+          LABEL: Required

--- a/languages/en.yaml
+++ b/languages/en.yaml
@@ -1,8 +1,13 @@
 PLUGIN_SNIPCART:
   SETTINGS:
+  TEMPLATES:
+    CART:
+      CHECKOUT: Checkout
   PAGE_OPTIONS:
     DEFAULT:
+      MODULAR_TITLE: Snipcart Items
     CATEGORY:
+      MODULAR_TITLE: Snipcart Items
     DETAIL:
       TITLE: Snipcart Item
       DESCRIPTION:

--- a/languages/en.yaml
+++ b/languages/en.yaml
@@ -1,0 +1,82 @@
+PLUGIN_SNIPCART:
+  SETTINGS:
+  PAGE_OPTIONS:
+    DEFAULT:
+    CATEGORY:
+    DETAIL:
+      TITLE: Snipcart Item
+      DESCRIPTION:
+        LABEL: Description
+      PRODUCT_ID:
+        LABEL: Product Id
+      PRICE:
+        LABEL: Price
+      CATEGORIES:
+        LABEL: Categories
+      FILE_GUID:
+        LABEL: File guid
+      STACKABLE:
+        LABEL: Stackable
+      SHIPABLE:
+        LABEL: Shipable
+      TAXABLE:
+        LABEL: Taxable
+      METADATA:
+        LABEL: JSON Metadata
+      DIMENSIONS:
+        TITLE: Shipping Dimensions
+        WEIGHT:
+          LABEL: Weight (g)
+        WIDTH:
+          LABEL: Width (cm)
+        LENGTH:
+          LABEL: Length (cm)
+        HEIGHT:
+          LABEL: Height (cm)
+      QUANTITY:
+        TITLE: Quantity
+        QUANTITY:
+          LABEL: Quantity
+        MIN:
+          LABEL: Min Quantity
+        MAX:
+          LABEL: Max Quantity
+        STEPS:
+          LABEL: Quantity Steps
+      TAXES:
+        TITLE: Taxes
+        TAXES:
+          LABEL: Taxes to apply
+        INCLUDED:
+          LABEL: Taxes included
+      PAYMENT:
+        TITLE: Payment
+        INTERVAL:
+          LABEL: Interval
+          OPTIONS:
+            DAY:
+              LABEL: Day
+            WEEK:
+              LABEL: Week
+            MONTH:
+              LABEL: Month
+            YEAR:
+              LABEL: Year
+        COUNT:
+          LABEL: Interval count
+        TRIAL:
+          LABEL: Trial period (days)
+      SUBSCRIPTION:
+        TITLE: Subscription
+        RECURRING_SHIPPING:
+          LABEL: Recurring Shipping
+        CANCELLATION_ACTION:
+          LABEL: Cancellation Action
+          OPTIONS:
+            PARTIAL: Partial Refund Last Payment
+            CANCEL: Cancel At Current Cycle End
+        PAUSING_ACTION:
+          LABEL: Pausing Action
+          OPTIONS:
+            KEEP: Keep Active Until End Of Billing Cycle
+            PAUSE: Pause And Realign Billing Cycle On Resume

--- a/languages/en.yaml
+++ b/languages/en.yaml
@@ -1,5 +1,7 @@
 PLUGIN_SNIPCART:
   SETTINGS:
+    BUILT_IN_CSS: Use built in CSS
+    API_KEY: API Key
   TEMPLATES:
     CHECKOUT: Checkout
     DETAILS: Details

--- a/snipcart.php
+++ b/snipcart.php
@@ -45,6 +45,7 @@ class SnipcartPlugin extends Plugin
         /** @var Types $types */
         $types = $event->types;
         $types->scanTemplates('plugins://snipcart/templates');
+        $types->scanBlueprints('plugins://snipcart/blueprints');
     }
 
     /**

--- a/templates/partials/snipcart_cart.html.twig
+++ b/templates/partials/snipcart_cart.html.twig
@@ -1,6 +1,6 @@
 <span class="snipcart-summary">
     <a href="#" class="snipcart-checkout">
-        Checkout
+        {{ 'PLUGIN_SNIPCART.TEMPLATES.CART.CHECKOUT'|t|e }}
         <i class="fa fa-shopping-cart">
             <span class="snipcart-total-items"></span>
         </i>

--- a/templates/partials/snipcart_cart.html.twig
+++ b/templates/partials/snipcart_cart.html.twig
@@ -1,6 +1,6 @@
 <span class="snipcart-summary">
     <a href="#" class="snipcart-checkout">
-        {{ 'PLUGIN_SNIPCART.TEMPLATES.CART.CHECKOUT'|t|e }}
+        {{ 'PLUGIN_SNIPCART.TEMPLATES.CHECKOUT'|t|e }}
         <i class="fa fa-shopping-cart">
             <span class="snipcart-total-items"></span>
         </i>

--- a/templates/partials/snipcart_detail_item.html.twig
+++ b/templates/partials/snipcart_detail_item.html.twig
@@ -1,3 +1,4 @@
+{% from "partials/snipcart_macros.html.twig" import add_to_cart %}
 {% set snipcart_image = page.media.images|first %}
 
 <div id="snipcart-detail" class="block-group">
@@ -12,60 +13,14 @@
             </span>
         </div>
         <p>
-            <a href="#"
-                class="button snipcart-add-item"
-                data-item-id="{{ page.header.snipcart.product_id }}"
-                data-item-name="{{ page.header.title }}"
-                data-item-price="{{ page.header.snipcart.price}}"
-                data-item-url="{{ page.url }}"
-                {% spaceless %}
-                {% if page.header.snipcart.categories %}
-                    data-item-categories="{{ page.header.snipcart.categories | join(', ') }}"
-                {% endif %}
-                {% if page.header.snipcart.description %}
-                    data-item-description="{{ page.header.snipcart.description }}"
-                {% endif %}
-
-                {% if page.header.snipcart.dimensions.weight %}
-                    data-item-weight="{{ page.header.snipcart.dimensions.weight }}"
-                {% endif %}
-                {% if page.header.snipcart.dimensions.width %}
-                    data-item-width="{{ page.header.snipcart.dimensions.width }}"
-                {% endif %}
-                {% if page.header.snipcart.dimensions.length %}
-                    data-item-length="{{ page.header.snipcart.dimensions.length }}"
-                {% endif %}
-                {% if page.header.snipcart.dimensions.height %}
-                    data-item-height="{{ page.header.snipcart.dimensions.height }}"
-                {% endif %}
-
-                {% if page.header.snipcart.quantity.min_quantity %}
-                    data-item-min-quantity="{{ page.header.snipcart.quantity.min_quantity }}"
-                {% endif %}
-                {% if page.header.snipcart.quantity.max_quantity %}
-                    data-item-max-quantity="{{ page.header.snipcart.quantity.max_quantity }}"
-                {% endif %}
-                {% if page.header.snipcart.quantity.quantity_step %}
-                    data-item-quantity-step="{{ page.header.snipcart.quantity.quantity_step }}"
-                {% endif %}
-
-                {% if page.header.snipcart.options.stackable %}
-                    data-item-stackable="{{ page.header.snipcart.options.stackable }}"
-                {% endif %}
-                {% if page.header.snipcart.options.shipable %}
-                    data-item-shipable="{{ page.header.snipcart.options.shipable }}"
-                {% endif %}
-                {% if page.header.snipcart.options.taxable %}
-                    data-item-taxable="{{ page.header.snipcart.options.taxable }}"
-                {% endif %}
-
-                {% if snipcart_image %}
-                    data-item-image="{{ snipcart_image.cropResize(50,50).url }}"
-                {% endif %}
-                {% endspaceless %}
-            >
-                <i class="fa fa-shopping-cart"></i> Add to Cart
-            </a>
+            {{ add_to_cart(
+                page.header.title,
+                page.url,
+                snipcart_image,
+                page.header.snipcart,
+                'button',
+                'Add to Cart',
+            ) | raw }}
         </p>
     </div>
     <div class="snipcart-details block">

--- a/templates/partials/snipcart_detail_item.html.twig
+++ b/templates/partials/snipcart_detail_item.html.twig
@@ -19,7 +19,7 @@
                 snipcart_image,
                 page.header.snipcart,
                 'button',
-                'Add to Cart',
+                'PLUGIN_SNIPCART.TEMPLATES.ADD_TO_CART'|t|e,
             ) | raw }}
         </p>
     </div>

--- a/templates/partials/snipcart_detail_item.html.twig
+++ b/templates/partials/snipcart_detail_item.html.twig
@@ -8,17 +8,17 @@
                 {{ snipcart_image.cropResize(400,400).html(page.header.title,'snipcart-thumb-image')|raw }}
             {% endif %}
             <span class="snipcart-price">
-            ${{ page.header.price }}
+            ${{ page.header.snipcart.price }}
             </span>
         </div>
         <p>
             <a href="#"
                 class="button snipcart-add-item"
-                data-item-id="{{ page.header.product_id }}"
+                data-item-id="{{ page.header.snipcart.product_id }}"
                 data-item-name="{{ page.header.title }}"
-                data-item-price="{{ page.header.price}}"
-                data-item-weight="{{ page.header.weight ?? 0}}"
-                data-item-description="{{ page.header.description ?? ''}}"
+                data-item-price="{{ page.header.snipcart.price}}"
+                data-item-weight="{{ page.header.snipcart.weight ?? 0}}"
+                data-item-description="{{ page.header.snipcart.description ?? ''}}"
                 data-item-url="{{ page.url }}"
                 {% spaceless %}
                 {% if snipcart_image %}

--- a/templates/partials/snipcart_detail_item.html.twig
+++ b/templates/partials/snipcart_detail_item.html.twig
@@ -16,7 +16,9 @@
                 class="button snipcart-add-item"
                 data-item-id="{{ page.header.product_id }}"
                 data-item-name="{{ page.header.title }}"
-                data-item-price="{{ page.header.price }}"
+                data-item-price="{{ page.header.price}}"
+                data-item-weight="{{ page.header.weight ?? 0}}"
+                data-item-description="{{ page.header.description ?? ''}}"
                 data-item-url="{{ page.url }}"
                 {% spaceless %}
                 {% if snipcart_image %}

--- a/templates/partials/snipcart_detail_item.html.twig
+++ b/templates/partials/snipcart_detail_item.html.twig
@@ -17,15 +17,52 @@
                 data-item-id="{{ page.header.snipcart.product_id }}"
                 data-item-name="{{ page.header.title }}"
                 data-item-price="{{ page.header.snipcart.price}}"
-                data-item-weight="{{ page.header.snipcart.weight ?? 0}}"
-                data-item-description="{{ page.header.snipcart.description ?? ''}}"
                 data-item-url="{{ page.url }}"
                 {% spaceless %}
+                {% if page.header.snipcart.categories %}
+                    data-item-categories="{{ page.header.snipcart.categories | join(', ') }}"
+                {% endif %}
+                {% if page.header.snipcart.description %}
+                    data-item-description="{{ page.header.snipcart.description }}"
+                {% endif %}
+
+                {% if page.header.snipcart.dimensions.weight %}
+                    data-item-weight="{{ page.header.snipcart.dimensions.weight }}"
+                {% endif %}
+                {% if page.header.snipcart.dimensions.width %}
+                    data-item-width="{{ page.header.snipcart.dimensions.width }}"
+                {% endif %}
+                {% if page.header.snipcart.dimensions.length %}
+                    data-item-length="{{ page.header.snipcart.dimensions.length }}"
+                {% endif %}
+                {% if page.header.snipcart.dimensions.height %}
+                    data-item-height="{{ page.header.snipcart.dimensions.height }}"
+                {% endif %}
+
+                {% if page.header.snipcart.quantity.min_quantity %}
+                    data-item-min-quantity="{{ page.header.snipcart.quantity.min_quantity }}"
+                {% endif %}
+                {% if page.header.snipcart.quantity.max_quantity %}
+                    data-item-max-quantity="{{ page.header.snipcart.quantity.max_quantity }}"
+                {% endif %}
+                {% if page.header.snipcart.quantity.quantity_step %}
+                    data-item-quantity-step="{{ page.header.snipcart.quantity.quantity_step }}"
+                {% endif %}
+
+                {% if page.header.snipcart.options.stackable %}
+                    data-item-stackable="{{ page.header.snipcart.options.stackable }}"
+                {% endif %}
+                {% if page.header.snipcart.options.shipable %}
+                    data-item-shipable="{{ page.header.snipcart.options.shipable }}"
+                {% endif %}
+                {% if page.header.snipcart.options.taxable %}
+                    data-item-taxable="{{ page.header.snipcart.options.taxable }}"
+                {% endif %}
+
                 {% if snipcart_image %}
                     data-item-image="{{ snipcart_image.cropResize(50,50).url }}"
                 {% endif %}
                 {% endspaceless %}
-                
             >
                 <i class="fa fa-shopping-cart"></i> Add to Cart
             </a>

--- a/templates/partials/snipcart_macros.html.twig
+++ b/templates/partials/snipcart_macros.html.twig
@@ -6,65 +6,89 @@
         data-item-url="{{ url }}"
         data-item-price="{{ attributes.price}}"
         {% spaceless %}
-        {% if attributes.categories %}
+        {% if image %}
+            data-item-image="{{ image.cropResize(50,50).url }}"
+        {% endif %}
+        {% if attributes.description is defined %}
+            data-item-description="{{ attributes.description }}"
+        {% endif %}
+        {% if attributes.categories is defined %}
             data-item-categories="{{ attributes.categories | join(', ') }}"
         {% endif %}
-        {% if attributes.description %}
-            data-item-description="{{ attributes.description }}"
+        {% if attributes.file_guid is defined %}
+            data-item-file-guid="{{ attributes.file_guid }}"
+        {% endif %}
+        {% if attributes.stackable is defined %}
+            data-item-stackable="{{ attributes.stackable ? 'true' : 'false' }}"
+        {% endif %}
+        {% if attributes.shipable is defined %}
+            data-item-shipable="{{ attributes.shipable ? 'true' : 'false' }}"
+        {% endif %}
+        {% if attributes.taxable is defined %}
+            data-item-taxable="{{ attributes.taxable ? 'true' : 'false' }}"
+        {% endif %}
+        {% if attributes.metadata %} {# TODO: to JSON is defined #}
+            data-item-metadata="{{ attributes.metadata }}"
         {% endif %}
 
         {# Shipping Dimensions #}
-        {% if attributes.dimensions.weight %}
+        {% if attributes.dimensions.weight is defined %}
             data-item-weight="{{ attributes.dimensions.weight }}"
         {% endif %}
-        {% if attributes.dimensions.width %}
+        {% if attributes.dimensions.width is defined %}
             data-item-width="{{ attributes.dimensions.width }}"
         {% endif %}
-        {% if attributes.dimensions.length %}
+        {% if attributes.dimensions.length is defined %}
             data-item-length="{{ attributes.dimensions.length }}"
         {% endif %}
-        {% if attributes.dimensions.height %}
+        {% if attributes.dimensions.height is defined %}
             data-item-height="{{ attributes.dimensions.height }}"
         {% endif %}
 
         {# Quantity #}
-        {% if attributes.quantity.min_quantity %}
+        {% if attributes.quantity.quantity is defined %}
+            data-item-quantity="{{ attributes.quantity.quantity }}"
+        {% endif %}
+        {% if attributes.quantity.min_quantity is defined %}
             data-item-min-quantity="{{ attributes.quantity.min_quantity }}"
         {% endif %}
-        {% if attributes.quantity.max_quantity %}
+        {% if attributes.quantity.max_quantity is defined %}
             data-item-max-quantity="{{ attributes.quantity.max_quantity }}"
         {% endif %}
-        {% if attributes.quantity.quantity_step %}
+        {% if attributes.quantity.quantity_step is defined %}
             data-item-quantity-step="{{ attributes.quantity.quantity_step }}"
         {% endif %}
 
-        {# Options #}
-        {% if attributes.options.stackable %}
-            data-item-stackable="{{ attributes.options.stackable }}"
+        {# Taxes #}
+        {% if attributes.taxes.taxes is defined %}
+            data-item-taxes="{{ attributes.taxes.taxes | join('|') }}"
         {% endif %}
-        {% if attributes.options.shipable %}
-            data-item-shipable="{{ attributes.options.shipable }}"
-        {% endif %}
-        {% if attributes.options.taxable %}
-            data-item-taxable="{{ attributes.options.taxable }}"
+        {% if attributes.taxes.has_included is defined %}
+            data-item-has-included="{{ attributes.taxes.has_included ? 'true' : 'false' }}"
         {% endif %}
 
-        {# other #}
-        {% if page.header.snipcart.interval %}
-            data-item-payment-interval="{{ page.header.snipcart.interval }}"
+        {# Payment #}
+        {% if attributes.payment.interval is defined %}
+            data-item-payment-interval="{{ attributes.payment.interval }}"
         {% endif %}
-        {% if page.header.snipcart.interval_count %}
-            data-item-payment-interval-count="{{ page.header.snipcart.interval_count }}"
+        {% if attributes.payment.interval_count is defined %}
+            data-item-payment-interval-count="{{ attributes.payment.interval_count }}"
         {% endif %}
-        {% if page.header.snipcart.trial %}
-            data-item-payment-trial="{{ page.header.snipcart.trial }}"
+        {% if attributes.payment.trial is defined %}
+            data-item-payment-trial="{{ attributes.payment.trial }}"
         {% endif %}
 
-
-        {# Image #}
-        {% if image %}
-            data-item-image="{{ image.cropResize(50,50).url }}"
+        {# Subscription #}
+        {% if attributes.subscription.recurring_shipping is defined %}
+            data-item-recurring-shipping="{{ attributes.subscription.recurring_shipping ? 'true' : 'false' }}"
         {% endif %}
+        {% if attributes.subscription.cancellation_action is defined %}
+            data-item-cancellation-action="{{ attributes.subscription.cancellation_action }}"
+        {% endif %}
+        {% if attributes.subscription.pausing_action is defined %}
+            data-item-pausing-action="{{ attributes.subscription.pausing_action }}"
+        {% endif %}
+
         {% endspaceless %}
     >
         <i class="fa fa-shopping-cart"></i> {{ text }}

--- a/templates/partials/snipcart_macros.html.twig
+++ b/templates/partials/snipcart_macros.html.twig
@@ -27,7 +27,7 @@
         {% if attributes.taxable is defined %}
             data-item-taxable="{{ attributes.taxable ? 'true' : 'false' }}"
         {% endif %}
-        {% if attributes.metadata %} {# TODO: to JSON is defined #}
+        {% if attributes.metadata %}
             data-item-metadata="{{ attributes.metadata }}"
         {% endif %}
 

--- a/templates/partials/snipcart_macros.html.twig
+++ b/templates/partials/snipcart_macros.html.twig
@@ -89,6 +89,21 @@
             data-item-pausing-action="{{ attributes.subscription.pausing_action }}"
         {% endif %}
 
+        {# Custom Fields #}
+        {% if attributes.custom is defined %}
+            {% for customField in attributes.custom %}
+				data-item-custom{{ loop.index }}-name="{{ customField.name }}"
+                data-item-custom{{ loop.index }}-required="{{ customField.required ? 'true' : 'false' }}"
+
+	            {% if customField.type == 'textarea' %}
+                    data-item-custom{{ loop.index }}-type="textarea"
+				{% endif %}
+				{% if customField.options %}
+                    data-item-custom{{ loop.index }}-options="{{ customField.options | join('|') }}"
+				{% endif %}
+            {% endfor %}
+        {% endif %}
+
         {% endspaceless %}
     >
         <i class="fa fa-shopping-cart"></i> {{ text }}

--- a/templates/partials/snipcart_macros.html.twig
+++ b/templates/partials/snipcart_macros.html.twig
@@ -1,0 +1,72 @@
+{% macro add_to_cart(name, url, image, attributes, classes, text) %}
+    <a href="#"
+        class="{{ classes }} snipcart-add-item"
+        data-item-id="{{ attributes.product_id }}"
+        data-item-name="{{ name }}"
+        data-item-url="{{ url }}"
+        data-item-price="{{ attributes.price}}"
+        {% spaceless %}
+        {% if attributes.categories %}
+            data-item-categories="{{ attributes.categories | join(', ') }}"
+        {% endif %}
+        {% if attributes.description %}
+            data-item-description="{{ attributes.description }}"
+        {% endif %}
+
+        {# Shipping Dimensions #}
+        {% if attributes.dimensions.weight %}
+            data-item-weight="{{ attributes.dimensions.weight }}"
+        {% endif %}
+        {% if attributes.dimensions.width %}
+            data-item-width="{{ attributes.dimensions.width }}"
+        {% endif %}
+        {% if attributes.dimensions.length %}
+            data-item-length="{{ attributes.dimensions.length }}"
+        {% endif %}
+        {% if attributes.dimensions.height %}
+            data-item-height="{{ attributes.dimensions.height }}"
+        {% endif %}
+
+        {# Quantity #}
+        {% if attributes.quantity.min_quantity %}
+            data-item-min-quantity="{{ attributes.quantity.min_quantity }}"
+        {% endif %}
+        {% if attributes.quantity.max_quantity %}
+            data-item-max-quantity="{{ attributes.quantity.max_quantity }}"
+        {% endif %}
+        {% if attributes.quantity.quantity_step %}
+            data-item-quantity-step="{{ attributes.quantity.quantity_step }}"
+        {% endif %}
+
+        {# Options #}
+        {% if attributes.options.stackable %}
+            data-item-stackable="{{ attributes.options.stackable }}"
+        {% endif %}
+        {% if attributes.options.shipable %}
+            data-item-shipable="{{ attributes.options.shipable }}"
+        {% endif %}
+        {% if attributes.options.taxable %}
+            data-item-taxable="{{ attributes.options.taxable }}"
+        {% endif %}
+
+        {# other #}
+        {% if page.header.snipcart.interval %}
+            data-item-payment-interval="{{ page.header.snipcart.interval }}"
+        {% endif %}
+        {% if page.header.snipcart.interval_count %}
+            data-item-payment-interval-count="{{ page.header.snipcart.interval_count }}"
+        {% endif %}
+        {% if page.header.snipcart.trial %}
+            data-item-payment-trial="{{ page.header.snipcart.trial }}"
+        {% endif %}
+
+
+        {# Image #}
+        {% if image %}
+            data-item-image="{{ image.cropResize(50,50).url }}"
+        {% endif %}
+        {% endspaceless %}
+    >
+        <i class="fa fa-shopping-cart"></i> {{ text }}
+    </a>
+{% endmacro %}

--- a/templates/partials/snipcart_macros.html.twig
+++ b/templates/partials/snipcart_macros.html.twig
@@ -4,7 +4,7 @@
         data-item-id="{{ attributes.product_id }}"
         data-item-name="{{ name }}"
         data-item-url="{{ url }}"
-        data-item-price="{{ attributes.price}}"
+        data-item-price="{{ attributes.price }}"
         {% spaceless %}
         {% if image %}
             data-item-image="{{ image.cropResize(50,50).url }}"
@@ -92,20 +92,18 @@
         {# Custom Fields #}
         {% if attributes.custom is defined %}
             {% for customField in attributes.custom %}
-				data-item-custom{{ loop.index }}-name="{{ customField.name }}"
+                data-item-custom{{ loop.index }}-name="{{ customField.name }}"
                 data-item-custom{{ loop.index }}-required="{{ customField.required ? 'true' : 'false' }}"
 
-	            {% if customField.type == 'textarea' %}
+                {% if customField.type == 'textarea' %}
                     data-item-custom{{ loop.index }}-type="textarea"
-				{% endif %}
-				{% if customField.options %}
+                {% endif %}
+                {% if customField.options %}
                     data-item-custom{{ loop.index }}-options="{{ customField.options | join('|') }}"
-				{% endif %}
+                {% endif %}
             {% endfor %}
         {% endif %}
-
         {% endspaceless %}
-    >
-        <i class="fa fa-shopping-cart"></i> {{ text }}
+    > <i class="fa fa-shopping-cart"></i> {{ text }}
     </a>
 {% endmacro %}

--- a/templates/partials/snipcart_product_item.html.twig
+++ b/templates/partials/snipcart_product_item.html.twig
@@ -16,7 +16,7 @@
     <p>
         <a href="{{ page.url }}"
             class="button button-small">
-            <i class="fa fa-info-circle"></i> Details
+            <i class="fa fa-info-circle"></i> {{ 'PLUGIN_SNIPCART.TEMPLATES.DETAILS'|t|e }}
         </a>
         {{ add_to_cart(
             page.header.title,
@@ -24,7 +24,7 @@
             snipcart_image,
             page.header.snipcart,
             'button button-small',
-            'Add',
+            'PLUGIN_SNIPCART.TEMPLATES.ADD'|t|e,
         ) | raw }}
     </p>
     </div>

--- a/templates/partials/snipcart_product_item.html.twig
+++ b/templates/partials/snipcart_product_item.html.twig
@@ -8,7 +8,7 @@
             <a href="{{ page.url }}">{{ snipcart_image.cropResize(200,200).html('page.header.title','snipcart-thumb-image')|raw }}</a>
         {% endif %}
         <span class="snipcart-price">
-        ${{ page.header.price }}
+        ${{ page.header.snipcart.price }}
         </span>
     </div>
     <div class="snipcart-details">
@@ -19,9 +19,9 @@
         </a>
         <a href="#"
             class="button button-small snipcart-add-item"
-            data-item-id="{{ page.header.product_id }}"
+            data-item-id="{{ page.header.snipcart.product_id }}"
             data-item-name="{{ page.header.title }}"
-            data-item-price="{{ page.header.price }}"
+            data-item-price="{{ page.header.snipcart.price }}"
             data-item-url="{{ page.url }}"
                 {% spaceless %}
                     {% if snipcart_image %}

--- a/templates/partials/snipcart_product_item.html.twig
+++ b/templates/partials/snipcart_product_item.html.twig
@@ -1,3 +1,4 @@
+{% from "partials/snipcart_macros.html.twig" import add_to_cart %}
 {% set snipcart_image = page.media.images|first %}
 
 <div class="snipcart-item block" >
@@ -17,21 +18,14 @@
             class="button button-small">
             <i class="fa fa-info-circle"></i> Details
         </a>
-        <a href="#"
-            class="button button-small snipcart-add-item"
-            data-item-id="{{ page.header.snipcart.product_id }}"
-            data-item-name="{{ page.header.title }}"
-            data-item-price="{{ page.header.snipcart.price }}"
-            data-item-url="{{ page.url }}"
-                {% spaceless %}
-                    {% if snipcart_image %}
-                        data-item-image="{{ snipcart_image.cropResize(50,50).url|raw }}"
-                    {% endif %}
-                {% endspaceless %}
-                
-        >
-            <i class="fa fa-shopping-cart"></i> Add
-        </a>
+        {{ add_to_cart(
+            page.header.title,
+            page.url,
+            snipcart_image,
+            page.header.snipcart,
+            'button button-small',
+            'Add',
+        ) | raw }}
     </p>
     </div>
 </div>

--- a/templates/partials/snipcart_subscription_item.html.twig
+++ b/templates/partials/snipcart_subscription_item.html.twig
@@ -19,7 +19,7 @@
                 snipcart_image,
                 page.header.snipcart,
                 'button',
-                'Add to Cart',
+                'PLUGIN_SNIPCART.TEMPLATES.ADD_TO_CART'|t|e,
             ) | raw }}
         </p>
     </div>

--- a/templates/partials/snipcart_subscription_item.html.twig
+++ b/templates/partials/snipcart_subscription_item.html.twig
@@ -1,3 +1,4 @@
+{% from "partials/snipcart_macros.html.twig" import add_to_cart %}
 {% set snipcart_image = page.media.images|first %}
 
 <div id="snipcart-detail" class="block-group">
@@ -12,28 +13,14 @@
             </span>
         </div>
         <p>
-            <a href="#"
-                class="button snipcart-add-item"
-                data-item-id="{{ page.header.snipcart.product_id }}"
-                data-item-name="{{ page.header.title }}"
-                data-item-price="{{ page.header.snipcart.price }}"
-                data-item-url="{{ page.url }}"
-                data-item-payment-interval="{{ page.header.snipcart.interval }}"
-                {% if page.header.snipcart.interval_count %}
-                    data-item-payment-interval-count="{{ page.header.snipcart.interval_count }}"
-                {% endif %}
-                {% if page.header.snipcart.trial %}
-                    data-item-payment-trial="{{ page.header.snipcart.trial }}"
-                {% endif %}
-                {% spaceless %}
-                {% if snipcart_image %}
-                    data-item-image="{{ snipcart_image.cropResize(50,50).url }}"
-                {% endif %}
-                {% endspaceless %}
-
-            >
-                <i class="fa fa-shopping-cart"></i> Add to Cart
-            </a>
+            {{ add_to_cart(
+                page.header.title,
+                page.url,
+                snipcart_image,
+                page.header.snipcart,
+                'button',
+                'Add to Cart',
+            ) | raw }}
         </p>
     </div>
     <div class="snipcart-details block">

--- a/templates/partials/snipcart_subscription_item.html.twig
+++ b/templates/partials/snipcart_subscription_item.html.twig
@@ -8,22 +8,22 @@
                 {{ snipcart_image.cropResize(400,400).html(page.header.title,'snipcart-thumb-image')|raw }}
             {% endif %}
             <span class="snipcart-price">
-            ${{ page.header.price }}
+            ${{ page.header.snipcart.price }}
             </span>
         </div>
         <p>
             <a href="#"
                 class="button snipcart-add-item"
-                data-item-id="{{ page.header.product_id }}"
+                data-item-id="{{ page.header.snipcart.product_id }}"
                 data-item-name="{{ page.header.title }}"
-                data-item-price="{{ page.header.price }}"
+                data-item-price="{{ page.header.snipcart.price }}"
                 data-item-url="{{ page.url }}"
-                data-item-payment-interval="{{ page.header.interval }}"
-                {% if page.header.interval_count %}
-                    data-item-payment-interval-count="{{ page.header.interval_count }}"
+                data-item-payment-interval="{{ page.header.snipcart.interval }}"
+                {% if page.header.snipcart.interval_count %}
+                    data-item-payment-interval-count="{{ page.header.snipcart.interval_count }}"
                 {% endif %}
-                {% if page.header.trial %}
-                    data-item-payment-trial="{{ page.header.trial }}"
+                {% if page.header.snipcart.trial %}
+                    data-item-payment-trial="{{ page.header.snipcart.trial }}"
                 {% endif %}
                 {% spaceless %}
                 {% if snipcart_image %}

--- a/templates/partials/snipcart_subscription_item_small.html.twig
+++ b/templates/partials/snipcart_subscription_item_small.html.twig
@@ -16,7 +16,7 @@
         <p>
             <a href="{{ page.url }}"
                class="button button-small">
-                <i class="fa fa-info-circle"></i> Details
+                <i class="fa fa-info-circle"></i> {{ 'PLUGIN_SNIPCART.TEMPLATES.DETAILS'|t|e }}
             </a>
             {{ add_to_cart(
                 page.header.title,
@@ -24,7 +24,7 @@
                 snipcart_image,
                 page.header.snipcart,
                 'button',
-                'Add',
+                'PLUGIN_SNIPCART.TEMPLATES.ADD'|t|e,
             ) | raw }}
         </p>
     </div>

--- a/templates/partials/snipcart_subscription_item_small.html.twig
+++ b/templates/partials/snipcart_subscription_item_small.html.twig
@@ -1,3 +1,4 @@
+{% from "partials/snipcart_macros.html.twig" import add_to_cart %}
 {% set snipcart_image = page.media.images|first %}
 
 <div class="snipcart-item block" >
@@ -17,28 +18,14 @@
                class="button button-small">
                 <i class="fa fa-info-circle"></i> Details
             </a>
-            <a href="#"
-               class="button button-small snipcart-add-item"
-               data-item-id="{{ page.header.snipcart.product_id }}"
-               data-item-name="{{ page.header.title }}"
-               data-item-price="{{ page.header.snipcart.price }}"
-               data-item-url="{{ page.url }}"
-               data-item-payment-interval="{{ page.header.snipcart.interval }}"
-                    {% if page.header.snipcart.interval_count %}
-                        data-item-payment-interval-count="{{ page.header.snipcart.interval_count }}"
-                    {% endif %}
-                    {% if page.header.snipcart.trial %}
-                        data-item-payment-trial="{{ page.header.snipcart.trial }}"
-                    {% endif %}
-                    {% spaceless %}
-                        {% if snipcart_image %}
-                            data-item-image="{{ snipcart_image.cropResize(50,50).url|raw }}"
-                        {% endif %}
-                    {% endspaceless %}
-
-            >
-                <i class="fa fa-shopping-cart"></i> Add
-            </a>
+            {{ add_to_cart(
+                page.header.title,
+                page.url,
+                snipcart_image,
+                page.header.snipcart,
+                'button',
+                'Add',
+            ) | raw }}
         </p>
     </div>
 </div>

--- a/templates/partials/snipcart_subscription_item_small.html.twig
+++ b/templates/partials/snipcart_subscription_item_small.html.twig
@@ -8,7 +8,7 @@
             <a href="{{ page.url }}">{{ snipcart_image.cropResize(200,200).html('page.header.title','snipcart-thumb-image')|raw }}</a>
         {% endif %}
         <span class="snipcart-price">
-            ${{ page.header.price }}<span class="snipcart-interval">/{{ page.header.interval }}</span>
+            ${{ page.header.snipcart.price }}<span class="snipcart-interval">/{{ page.header.snipcart.interval }}</span>
         </span>
     </div>
     <div class="snipcart-details">
@@ -19,16 +19,16 @@
             </a>
             <a href="#"
                class="button button-small snipcart-add-item"
-               data-item-id="{{ page.header.product_id }}"
+               data-item-id="{{ page.header.snipcart.product_id }}"
                data-item-name="{{ page.header.title }}"
-               data-item-price="{{ page.header.price }}"
+               data-item-price="{{ page.header.snipcart.price }}"
                data-item-url="{{ page.url }}"
-               data-item-payment-interval="{{ page.header.interval }}"
-                    {% if page.header.interval_count %}
-                        data-item-payment-interval-count="{{ page.header.interval_count }}"
+               data-item-payment-interval="{{ page.header.snipcart.interval }}"
+                    {% if page.header.snipcart.interval_count %}
+                        data-item-payment-interval-count="{{ page.header.snipcart.interval_count }}"
                     {% endif %}
-                    {% if page.header.trial %}
-                        data-item-payment-trial="{{ page.header.trial }}"
+                    {% if page.header.snipcart.trial %}
+                        data-item-payment-trial="{{ page.header.snipcart.trial }}"
                     {% endif %}
                     {% spaceless %}
                         {% if snipcart_image %}


### PR DESCRIPTION
This PR adds more features to the Snipcart plugin, with focus on admin:
- add English and German translations
  - page settings
  - templates
    - closes #20 
  - plugin settings
- add more admin options
  - modular settings for child items
![image](https://github.com/user-attachments/assets/262acc59-f6e0-4d51-b68e-6ea85e45170e)
  - all Snipcart v2 options in detail page
![image](https://github.com/user-attachments/assets/0e2b2565-cdae-4ecc-8b79-8bcc32b6782f)
- include more Snipcart features
  - all item metadata in add cart button
  - reuse cart button as a macro
  - custom fields support
![image](https://github.com/user-attachments/assets/7b561c6f-95b1-4c2f-8822-ecc61700936e)